### PR TITLE
Support Rake newer versions

### DIFF
--- a/lib/grape_logging/loggers/filter_parameters.rb
+++ b/lib/grape_logging/loggers/filter_parameters.rb
@@ -1,6 +1,8 @@
 module GrapeLogging
   module Loggers
     class FilterParameters < GrapeLogging::Loggers::Base
+      require 'active_support/parameter_filter'
+
       AD_PARAMS = 'action_dispatch.request.parameters'.freeze
       REQUEST_LENGTH_EXCEEDED = { "alert": "request_length_exceeded",
                                   "alert_description": "Request length exceeded maximum allowed characters and was removed due to logging system constraints."
@@ -20,7 +22,7 @@ module GrapeLogging
       private
 
       def parameter_filter
-        @parameter_filter ||= ActionDispatch::Http::ParameterFilter.new(@filter_parameters)
+        @parameter_filter ||= ActiveSupport::ParameterFilter.new(@filter_parameters)
       end
 
       def safe_parameters(request)

--- a/lib/grape_logging/loggers/response.rb
+++ b/lib/grape_logging/loggers/response.rb
@@ -13,12 +13,12 @@ module GrapeLogging
       # For example, if you POST on a PUT endpoint, response.body is egal to """".
       # It's strange but it's the Grape behavior...
       def serialized_response_body(response)
-        if response.body.first.to_s.length > MAX_RESPONSE_LENGTH
+        if response.body.body.length > MAX_RESPONSE_LENGTH
           JSON.parse(RESPONSE_LENGTH_EXCEEDED)
         else
-          JSON.parse(response.body.first.to_s)
+          JSON.parse(response.body.body)
         end
-      rescue => e
+      rescue StandardError
         response.body
       end
     end


### PR DESCRIPTION
### :pushpin: References
* **Issue / Jira ticket:** -
* **Related pull-requests:** -

### :dart: What is the goal?
Support newer Rake response without changing the whole project structure (sync with the upstream) that could imply redoing all our custom changes.