### PR TITLE
Fix format for Grape responses

### DIFF
--- a/lib/grape_logging/loggers/response.rb
+++ b/lib/grape_logging/loggers/response.rb
@@ -2,24 +2,37 @@ module GrapeLogging
   module Loggers
     class Response < GrapeLogging::Loggers::Base
       MAX_RESPONSE_LENGTH = 180_000
-      RESPONSE_LENGTH_EXCEEDED = "{\"alert\":\"response_length_exceeded\",\"alert_description\":\"Response length exceeded maximum allowed characters and was removed due to logging system constraints.\"}".freeze
+      MAX_RESPONSE_BODY = {
+        'alert': 'response_length_exceeded',
+        'alert_description':
+          'Response length exceeded maximum allowed characters and was removed due to logging system constraints.'
+      }.freeze
 
       def parameters(_, response)
         response ? { response: serialized_response_body(response) } : {}
       end
 
       private
+
       # In some cases, response.body is not parseable by JSON.
       # For example, if you POST on a PUT endpoint, response.body is egal to """".
       # It's strange but it's the Grape behavior...
       def serialized_response_body(response)
-        if response.body.body.length > MAX_RESPONSE_LENGTH
-          JSON.parse(RESPONSE_LENGTH_EXCEEDED)
-        else
-          JSON.parse(response.body.body)
-        end
+        body = if response.body.respond_to?(:body) # Rails responses
+                 response.body.body
+               else # Grape responses
+                 response.body.first
+               end
+
+        serialize_body(body)
       rescue StandardError
         response.body
+      end
+
+      def serialize_body(body)
+        return MAX_RESPONSE_BODY if body.length > MAX_RESPONSE_LENGTH
+
+        JSON.parse(body)
       end
     end
   end


### PR DESCRIPTION
### :pushpin: References
* **Related pull-requests:** #7 

### :dart: What is the goal?
The previous PR introduced an error on the parsing for Grape. Since we receive now different responses (Rails - `ActionDispatch::Response::RackBody` and Grape - `Rack::Response`), we need to navigate them differently.