### PR TITLE
add compatibility to kwargs in `GrapeLogging::Middleware::RequestLogger`

### DIFF
--- a/grape_logging.gemspec
+++ b/grape_logging.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'grape'
+  spec.add_dependency 'grape', '>= 2.4.0'
 
   spec.add_development_dependency 'bundler', '~> 1.8'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/grape_logging/loggers/response.rb
+++ b/lib/grape_logging/loggers/response.rb
@@ -1,11 +1,11 @@
 module GrapeLogging
   module Loggers
     class Response < GrapeLogging::Loggers::Base
-      MAX_RESPONSE_LENGTH = 180_000
+      MAX_RESPONSE_LENGTH = 100
       MAX_RESPONSE_BODY = {
         'alert': 'response_length_exceeded',
         'alert_description':
-          'Response length exceeded maximum allowed characters and was removed due to logging system constraints.'
+          'Response length exceeded.'
       }.freeze
 
       def parameters(_, response)

--- a/lib/grape_logging/middleware/request_logger.rb
+++ b/lib/grape_logging/middleware/request_logger.rb
@@ -11,7 +11,8 @@ module GrapeLogging
         GrapeLogging::Timings.append_db_runtime(event)
       end if defined?(ActiveRecord)
 
-      def initialize(app, options = {})
+      def initialize(app, **options)
+        options ||= {}
         super
 
         @included_loggers = @options[:include] || []

--- a/lib/grape_logging/version.rb
+++ b/lib/grape_logging/version.rb
@@ -1,3 +1,3 @@
 module GrapeLogging
-  VERSION = '1.3.0'
+  VERSION = '1.4.0'
 end


### PR DESCRIPTION
- pass `options` as kwargs in initializer;
- add `grape '>= 2.4.0'` as dependency;
- bump gem to `1.4.0`.